### PR TITLE
Change from using OTX hostname api to domain api

### DIFF
--- a/providers/otx.go
+++ b/providers/otx.go
@@ -30,7 +30,7 @@ func NewOTXProvider(config *Config) Provider {
 }
 
 func (o *OTXProvider) formatURL(domain string, page int) string {
-	return fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/hostname/%s/url_list?limit=%d&page=%d",
+	return fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/url_list?limit=%d&page=%d",
 		domain, otxResultsLimit, page,
 	)
 }


### PR DESCRIPTION
Currently gau is utilising the OTX `hostname` API rather than the `domain`. this means that a lot of potential URLs are not being found.

For example if we were to analyse bbc.co.uk:

`hostname` endpoint: https://otx.alienvault.com/api/v1/indicators/hostname/bbc.co.uk/url_list?limit=200
176 results

`domain` endpoint: https://otx.alienvault.com/api/v1/indicators/domain/bbc.co.uk/url_list?limit=200
36799 results

OTX treats `hostname` as a subset of a domain, and so I believe gau should use the domain endpoint.

There is a potential area of confusion here though, which is when using subdomains such as www:

https://otx.alienvault.com/api/v1/indicators/domain/www.bbc.co.uk/url_list?limit=200 returns 0 results, but this makes sense as www is a subdomain of bbc.co.uk. If this is problematic perhaps gau could strip off subdomains? Personally I don't think it's an issue.