### PR TITLE
Fixed the OTX provider due do API path confusion

### DIFF
--- a/providers/otx.go
+++ b/providers/otx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"github.com/bobesa/go-domain-util/domainutil"
 )
 
 type OTXProvider struct {
@@ -31,9 +32,19 @@ func NewOTXProvider(config *Config) Provider {
 }
 
 func (o *OTXProvider) formatURL(domain string, page int) string {
-	return fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/url_list?limit=%d&page=%d",
-		domain, otxResultsLimit, page,
-	)
+	if !domainutil.HasSubdomain(domain) {
+		return fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/url_list?limit=%d&page=%d",
+			domain, otxResultsLimit, page,
+		)
+	} else if domainutil.HasSubdomain(domain) && o.IncludeSubdomains {
+		return fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/url_list?limit=%d&page=%d",
+			domain, otxResultsLimit, page,
+		)
+	} else {
+		return fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/hostname/%s/url_list?limit=%d&page=%d",
+			domain, otxResultsLimit, page,
+		)
+	}
 }
 
 func (o *OTXProvider) Fetch(domain string, results chan<- string) error {
@@ -53,7 +64,13 @@ func (o *OTXProvider) Fetch(domain string, results chan<- string) error {
 
 		for _, entry := range result.URLList {
 			if o.IncludeSubdomains {
-				results <- entry.URL
+				if !domainutil.HasSubdomain(domain) {
+					results <- entry.URL
+				} else {
+					if strings.Contains(strings.ToLower(entry.Hostname), strings.ToLower(domain)) {
+						results <- entry.URL
+					}
+				}
 			} else {
 				if strings.EqualFold(domain, entry.Hostname) {
 					results <- entry.URL

--- a/providers/otx.go
+++ b/providers/otx.go
@@ -38,7 +38,7 @@ func (o *OTXProvider) formatURL(domain string, page int) string {
 		)
 	} else if domainutil.HasSubdomain(domain) && o.IncludeSubdomains {
 		return fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/domain/%s/url_list?limit=%d&page=%d",
-			domain, otxResultsLimit, page,
+			domainutil.Domain(domain), otxResultsLimit, page,
 		)
 	} else {
 		return fmt.Sprintf("https://otx.alienvault.com/api/v1/indicators/hostname/%s/url_list?limit=%d&page=%d",


### PR DESCRIPTION
Hey !

First, thank you for this tool, I used it a lot during engagement and find it very handy :)

I realized no later than today that myself and one of my coworkers had different outputs but targeting the same hostname (subdomain.domain.com).

Intercepting the `gau` requests and reading a bit about the OTX documentation made me realize that the API endpoint currently used in the OTX provider would return data **only** when a domain is provided, but nothing when a subdomain is provided (https://otx.alienvault.com/assets/static/external_api.html)

I just made a couple of changes to make sure the right endpoint is used depending on the input (domain or subdomain) and also made sure that the `-subs` switch would still work. If you feed the `x.y.z` hostname to `gau` without the `-subs` switch, the OTX provider will use `/api/v1/indicators/hostname/{hostname}/{section}` as this endpoint returns URL for a hostname that is not a domain. Now if you want the subdomains of that hostname (e.g. `a.x.y.z` and `b.x.y.z`), it will use the `/api/v1/indicators/domain/{domain}/{section}` and for every key in the return dict, check if it contains the submitted hostname.

I didn't include the `go.mod` and the `go.sum` as I don't know your opinion about versioning but feel free to add them if you feel the PR useful and you're into reproductible builds :)