### PR TITLE
Optimize Dockerfile and implement CI/CD to DockerHub

### DIFF
--- a/.github/workflows/cicd-to-dockerhub.yml
+++ b/.github/workflows/cicd-to-dockerhub.yml
@@ -1,0 +1,36 @@
+name: cicd-to-dockerhub
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/gau:latest
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,24 @@
-FROM golang:1.14
+# Build image: golang:1.14-alpine3.13
+FROM golang@sha256:ef409ff24dd3d79ec313efe88153d703fee8b80a522d294bb7908216dc7aa168 as build
 
-WORKDIR /app/gau
+WORKDIR /app
 
 COPY . .
 RUN go mod download
 RUN go build -o ./build/gau
 
 ENTRYPOINT ["/app/gau/build/gau"]
+
+# Image: alpine:3.14.1
+FROM alpine@sha256:be9bdc0ef8e96dbc428dc189b31e2e3b05523d96d12ed627c37aa2936653258c
+
+RUN apk -U upgrade --no-cache
+COPY --from=build /app/build/gau /usr/local/bin/gau
+
+RUN adduser \
+    --gecos "" \
+    --disabled-password \
+    gau
+
+USER gau
+ENTRYPOINT ["gau"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,11 @@ FROM golang@sha256:ef409ff24dd3d79ec313efe88153d703fee8b80a522d294bb7908216dc7aa
 WORKDIR /app
 
 COPY . .
-RUN go mod download
-RUN go build -o ./build/gau
+RUN go mod download && go build -o ./build/gau
 
 ENTRYPOINT ["/app/gau/build/gau"]
 
-# Image: alpine:3.14.1
+# Release image: alpine:3.14.1
 FROM alpine@sha256:be9bdc0ef8e96dbc428dc189b31e2e3b05523d96d12ed627c37aa2936653258c
 
 RUN apk -U upgrade --no-cache


### PR DESCRIPTION
This PR fixes and modifies the Dockerfile in GAU with the following considerations:

- The current Dockerfile does not leverage multi-stage builds. The current image has about 868MB with the current Dockerfile instructions. With multi-stage build it has about 16MB.
- Adds deterministic base images for reproducible builds.
- Added a least-privileged user in compliance with Docker security best practices.

We also have a workflow with a CICD pipeline to DockerHub. All you need to do is to add the DOCKER_HUB_USERNAME and DOCKER_HUB_ACCESS_TOKEN secrets to the repository and all pushes/merges to the master branch will automatically push an image to DockerHub.