### PR TITLE
New feature: ignore same endpoints with different parameters

### DIFF
--- a/.gau.toml
+++ b/.gau.toml
@@ -2,6 +2,7 @@ threads = 2
 verbose = false
 retries = 15
 subdomains = false
+parameters = false
 providers = ["gau","commoncrawl","otx","urlscan"]
 blacklist = ["ttf","woff","svg","png","jpg"]
 json = false

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ gau -h
 |`--fc`| list of status codes to filter | gau --fc 404,302 |
 |`--from`| fetch urls from date (format: YYYYMM) | gau --from 202101 |
 |`--ft`| list of mime-types to filter | gau --ft text/plain|
+|`--fp`| remove different parameters of the same endpoint | gau --fp|
 |`--json`| output as json | gau --json |
 |`--mc`| list of status codes to match | gau --mc 200,500 |
 |`--mt`| list of mime-types to match |gau --mt text/html,application/json|

--- a/cmd/gau/main.go
+++ b/cmd/gau/main.go
@@ -8,8 +8,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
-	"net/http"
-	_ "net/http/pprof"
 	"sync"
 )
 
@@ -21,9 +19,6 @@ func main() {
 			log.Warnf("error reading config: %v", err)
 		}
 	}
-
-
-	log.Println(http.ListenAndServe("localhost:8989", nil))
 
 	pMap := make(runner.ProvidersMap)
 	for _, provider := range cfg.Providers {

--- a/cmd/gau/main.go
+++ b/cmd/gau/main.go
@@ -8,6 +8,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
+	"net/http"
+	_ "net/http/pprof"
 	"sync"
 )
 
@@ -19,6 +21,9 @@ func main() {
 			log.Warnf("error reading config: %v", err)
 		}
 	}
+
+
+	log.Println(http.ListenAndServe("localhost:8989", nil))
 
 	pMap := make(runner.ProvidersMap)
 	for _, provider := range cfg.Providers {
@@ -56,12 +61,12 @@ func main() {
 	if config.JSON {
 		go func() {
 			defer writeWg.Done()
-			output.WriteURLsJSON(out, results, config.Blacklist)
+			output.WriteURLsJSON(out, results, config.Blacklist, config.RemoveParameters)
 		}()
 	} else {
 		go func() {
 			defer writeWg.Done()
-			if err = output.WriteURLs(out, results, config.Blacklist); err != nil {
+			if err = output.WriteURLs(out, results, config.Blacklist, config.RemoveParameters); err != nil {
 				log.Fatalf("error writing results: %v\n", err)
 			}
 		}()

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -14,7 +14,7 @@ type JSONResult struct {
 }
 
 func WriteURLs(writer io.Writer, results <-chan string, blacklistMap map[string]struct{}, RemoveParameters bool) error {
-	lastURL := make(map[string]bool)
+	lastURL := make(map[string]struct{})
 	for result := range results {
 		buf := bytebufferpool.Get()
 		if len(blacklistMap) != 0 {
@@ -36,10 +36,10 @@ func WriteURLs(writer io.Writer, results <-chan string, blacklistMap map[string]
 			if err != nil {
 				continue
 			}
-			if lastURL[u.Host+u.Path] {
+			if _, ok := lastURL[u.Host+u.Path]; ok {
 				continue
 			} else {
-				lastURL[u.Host+u.Path] = true ;
+				lastURL[u.Host+u.Path] = struct{}{} ;
 			}
 
 		}

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -5,7 +5,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const Version = `2.0.8`
+const Version = `2.0.9`
 
 // Provider is a generic interface for all archive fetchers
 type Provider interface {

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -23,6 +23,7 @@ type Config struct {
 	Verbose           bool
 	MaxRetries        uint
 	IncludeSubdomains bool
+	RemoveParameters  bool
 	Client            *fasthttp.Client
 	Providers         []string
 	Blacklist         map[string]struct{}

--- a/runner/flags/flags.go
+++ b/runner/flags/flags.go
@@ -29,6 +29,7 @@ type Config struct {
 	Verbose           bool              `mapstructure:"verbose"`
 	MaxRetries        uint              `mapstructure:"retries"`
 	IncludeSubdomains bool              `mapstructure:"subdomains"`
+	RemoveParameters  bool              `mapstructure:"parameters"`
 	Providers         []string          `mapstructure:"providers"`
 	Blacklist         []string          `mapstructure:"blacklist"`
 	JSON              bool              `mapstructure:"json"`
@@ -60,6 +61,7 @@ func (c *Config) ProviderConfig() (*providers.Config, error) {
 		Verbose:           c.Verbose,
 		MaxRetries:        c.MaxRetries,
 		IncludeSubdomains: c.IncludeSubdomains,
+		RemoveParameters:  c.RemoveParameters,
 		Client: &fasthttp.Client{
 			TLSConfig: &tls.Config{
 				InsecureSkipVerify: true,
@@ -98,6 +100,7 @@ func New() *Options {
 	pflag.StringSlice("blacklist", []string{}, "list of extensions to skip")
 	pflag.StringSlice("providers", []string{}, "list of providers to use (wayback,commoncrawl,otx,urlscan)")
 	pflag.Bool("subs", false, "include subdomains of target domain")
+	pflag.Bool("fp", false, "remove different parameters of the same endpoint")
 	pflag.Bool("verbose", false, "show verbose output")
 	pflag.Bool("json", false, "output as json")
 
@@ -160,6 +163,7 @@ func (o *Options) DefaultConfig() *Config {
 		Verbose:           false,
 		MaxRetries:        5,
 		IncludeSubdomains: false,
+		RemoveParameters:  false,
 		Providers:         []string{"wayback", "commoncrawl", "otx", "urlscan"},
 		Blacklist:         []string{},
 		JSON:              false,
@@ -182,6 +186,7 @@ func (o *Options) getFlagValues(c *Config) {
 	threads := o.viper.GetUint("threads")
 	blacklist := o.viper.GetStringSlice("blacklist")
 	subs := o.viper.GetBool("subs")
+	fp := o.viper.GetBool("fp")
 
 	if version {
 		fmt.Printf("gau version: %s\n", providers.Version)
@@ -216,6 +221,10 @@ func (o *Options) getFlagValues(c *Config) {
 
 	if subs {
 		c.IncludeSubdomains = subs
+	}
+
+	if fp {
+		c.RemoveParameters = fp
 	}
 
 	if json {


### PR DESCRIPTION
Hi !

While doing bug bounty I sometimes don't want to see duplicated endpoints with the only difference being the parameters, so I wrote this option.

I was concerned that creating a new `map` that stores every URL would be memory intensive, but did some profiling with `pprof` and it doesn't seem to affect the tool too much.

I think that the description/name of the "--fp" option can be improved, feel free to modify it.

Thanks, great tool (: