### PR TITLE
Add provider field in json output

### DIFF
--- a/cmd/gau/main.go
+++ b/cmd/gau/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"bufio"
+	"io"
+	"os"
+	"sync"
+
 	"github.com/lc/gau/v2/pkg/output"
 	"github.com/lc/gau/v2/runner"
 	"github.com/lc/gau/v2/runner/flags"
 	log "github.com/sirupsen/logrus"
-	"io"
-	"os"
-	"sync"
 )
 
 func main() {
@@ -36,7 +37,7 @@ func main() {
 		log.Warn(err)
 	}
 
-	results := make(chan string)
+	results := make(chan output.Result)
 
 	var out io.Writer
 	// Handle results in background

--- a/pkg/providers/commoncrawl/commoncrawl.go
+++ b/pkg/providers/commoncrawl/commoncrawl.go
@@ -9,6 +9,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/lc/gau/v2/pkg/httpclient"
+	"github.com/lc/gau/v2/pkg/output"
 	"github.com/lc/gau/v2/pkg/providers"
 	"github.com/sirupsen/logrus"
 )
@@ -55,7 +56,7 @@ func (c *Client) Name() string {
 
 // Fetch fetches all urls for a given domain and sends them to a channel.
 // It returns an error should one occur.
-func (c *Client) Fetch(ctx context.Context, domain string, results chan string) error {
+func (c *Client) Fetch(ctx context.Context, domain string, results chan output.Result) error {
 	p, err := c.getPagination(domain)
 	if err != nil {
 		return err
@@ -93,7 +94,10 @@ paginate:
 					return fmt.Errorf("received an error from commoncrawl: %s", res.Error)
 				}
 
-				results <- res.URL
+				results <- output.Result{
+					URL:      res.URL,
+					Provider: Name,
+				}
 			}
 		}
 	}

--- a/pkg/providers/otx/otx.go
+++ b/pkg/providers/otx/otx.go
@@ -3,9 +3,11 @@ package otx
 import (
 	"context"
 	"fmt"
+
 	"github.com/bobesa/go-domain-util/domainutil"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/lc/gau/v2/pkg/httpclient"
+	"github.com/lc/gau/v2/pkg/output"
 	"github.com/lc/gau/v2/pkg/providers"
 	"github.com/sirupsen/logrus"
 )
@@ -45,7 +47,7 @@ func (c *Client) Name() string {
 	return Name
 }
 
-func (c *Client) Fetch(ctx context.Context, domain string, results chan string) error {
+func (c *Client) Fetch(ctx context.Context, domain string, results chan output.Result) error {
 paginate:
 	for page := 1; ; page++ {
 		select {
@@ -66,7 +68,10 @@ paginate:
 			}
 
 			for _, entry := range result.URLList {
-				results <- entry.URL
+				results <- output.Result{
+					URL:      entry.URL,
+					Provider: Name,
+				}
 			}
 
 			if !result.HasNext {

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -2,6 +2,8 @@ package providers
 
 import (
 	"context"
+
+	"github.com/lc/gau/v2/pkg/output"
 	"github.com/valyala/fasthttp"
 )
 
@@ -9,7 +11,7 @@ const Version = `2.1.2`
 
 // Provider is a generic interface for all archive fetchers
 type Provider interface {
-	Fetch(ctx context.Context, domain string, results chan string) error
+	Fetch(ctx context.Context, domain string, results chan output.Result) error
 	Name() string
 }
 

--- a/pkg/providers/urlscan/urlscan.go
+++ b/pkg/providers/urlscan/urlscan.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/lc/gau/v2/pkg/httpclient"
+	"github.com/lc/gau/v2/pkg/output"
 	"github.com/lc/gau/v2/pkg/providers"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 const (
@@ -32,7 +34,7 @@ func New(c *providers.Config) *Client {
 func (c *Client) Name() string {
 	return Name
 }
-func (c *Client) Fetch(ctx context.Context, domain string, results chan string) error {
+func (c *Client) Fetch(ctx context.Context, domain string, results chan output.Result) error {
 	var searchAfter string
 	var header httpclient.Header
 
@@ -73,7 +75,10 @@ paginate:
 			total := len(result.Results)
 			for i, res := range result.Results {
 				if res.Page.Domain == domain || (c.config.IncludeSubdomains && strings.HasSuffix(res.Page.Domain, domain)) {
-					results <- res.Page.URL
+					results <- output.Result{
+						URL:      res.Page.URL,
+						Provider: Name,
+					}
 				}
 
 				if i == total-1 {

--- a/pkg/providers/wayback/wayback.go
+++ b/pkg/providers/wayback/wayback.go
@@ -3,8 +3,10 @@ package wayback
 import (
 	"context"
 	"fmt"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/lc/gau/v2/pkg/httpclient"
+	"github.com/lc/gau/v2/pkg/output"
 	"github.com/lc/gau/v2/pkg/providers"
 	"github.com/sirupsen/logrus"
 )
@@ -38,7 +40,7 @@ type waybackResult [][]string
 
 // Fetch fetches all urls for a given domain and sends them to a channel.
 // It returns an error should one occur.
-func (c *Client) Fetch(ctx context.Context, domain string, results chan string) error {
+func (c *Client) Fetch(ctx context.Context, domain string, results chan output.Result) error {
 	pages, err := c.getPagination(domain)
 	if err != nil {
 		return fmt.Errorf("failed to fetch wayback pagination: %s", err)
@@ -73,7 +75,10 @@ func (c *Client) Fetch(ctx context.Context, domain string, results chan string) 
 			for i, entry := range result {
 				// Skip first result by default
 				if i != 0 {
-					results <- entry[0]
+					results <- output.Result{
+						URL:      entry[0],
+						Provider: Name,
+					}
 				}
 			}
 		}

--- a/runner/flags/flags.go
+++ b/runner/flags/flags.go
@@ -4,17 +4,22 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"github.com/lc/gau/v2/pkg/providers"
-	"github.com/lynxsecurity/pflag"
-	"github.com/lynxsecurity/viper"
-	log "github.com/sirupsen/logrus"
-	"github.com/valyala/fasthttp"
-	"github.com/valyala/fasthttp/fasthttpproxy"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/lc/gau/v2/pkg/providers"
+	"github.com/lc/gau/v2/pkg/providers/commoncrawl"
+	"github.com/lc/gau/v2/pkg/providers/otx"
+	"github.com/lc/gau/v2/pkg/providers/urlscan"
+	"github.com/lc/gau/v2/pkg/providers/wayback"
+	"github.com/lynxsecurity/pflag"
+	"github.com/lynxsecurity/viper"
+	log "github.com/sirupsen/logrus"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttpproxy"
 )
 
 type URLScanConfig struct {
@@ -101,7 +106,14 @@ func New() *Options {
 	pflag.Uint("retries", 0, "retries for HTTP client")
 	pflag.String("proxy", "", "http proxy to use")
 	pflag.StringSlice("blacklist", []string{}, "list of extensions to skip")
-	pflag.StringSlice("providers", []string{}, "list of providers to use (wayback,commoncrawl,otx,urlscan)")
+	pflag.StringSlice(
+		"providers",
+		[]string{},
+		fmt.Sprintf(
+			"list of providers to use (%s,%s,%s,%s)",
+			wayback.Name, commoncrawl.Name, otx.Name, urlscan.Name,
+		),
+	)
 	pflag.Bool("subs", false, "include subdomains of target domain")
 	pflag.Bool("fp", false, "remove different parameters of the same endpoint")
 	pflag.Bool("verbose", false, "show verbose output")
@@ -168,10 +180,15 @@ func (o *Options) DefaultConfig() *Config {
 		MaxRetries:        5,
 		IncludeSubdomains: false,
 		RemoveParameters:  false,
-		Providers:         []string{"wayback", "commoncrawl", "otx", "urlscan"},
-		Blacklist:         []string{},
-		JSON:              false,
-		Outfile:           "",
+		Providers: []string{
+			commoncrawl.Name,
+			otx.Name,
+			urlscan.Name,
+			wayback.Name,
+		},
+		Blacklist: []string{},
+		JSON:      false,
+		Outfile:   "",
 	}
 
 	o.getFlagValues(c)


### PR DESCRIPTION
Hey there,

I had a need to know from which provider which URLs came from, so I added `provider` field in json output.
Unfortunately, I haven't found a way to do it in a backward compatible manner.

Also, provider names now referenced as variables instead of just plain strings so it's less likely to shoot yourself in the foot in the future.
I hope this PR is going to be helpful.

Cheers!