### PR TITLE
Refactor to dry up code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/lc/gau/v2
 
-go 1.17
+go 1.20
 
 require (
 	github.com/bobesa/go-domain-util v0.0.0-20190911083921-4033b5f7dd89
+	github.com/deckarep/golang-set/v2 v2.3.0
 	github.com/json-iterator/go v1.1.12
 	github.com/lynxsecurity/pflag v1.1.3
 	github.com/lynxsecurity/viper v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/bobesa/go-domain-util v0.0.0-20190911083921-4033b5f7dd89/go.mod h1:/0
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.3.0 h1:qs18EKUfHm2X9fA50Mr/M5hccg2tNnVqsiBImnyDs0g=
+github.com/deckarep/golang-set/v2 v2.3.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -36,10 +36,9 @@ func MakeRequest(c *fasthttp.Client, url string, maxRetries uint, timeout uint, 
 		req.SetRequestURI(url)
 		respBody, err = doReq(c, req, timeout)
 		if err == nil {
-			goto done
+			break
 		}
 	}
-done:
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/commoncrawl/commoncrawl.go
+++ b/pkg/providers/commoncrawl/commoncrawl.go
@@ -60,9 +60,7 @@ func (c *Client) Fetch(ctx context.Context, domain string, results chan string) 
 	}
 	// 0 pages means no results
 	if p.Pages == 0 {
-		if c.config.Verbose {
-			logrus.WithFields(logrus.Fields{"provider": Name}).Infof("no results for %s", domain)
-		}
+		logrus.WithFields(logrus.Fields{"provider": Name}).Infof("no results for %s", domain)
 		return nil
 	}
 
@@ -72,9 +70,7 @@ paginate:
 		case <-ctx.Done():
 			break paginate
 		default:
-			if c.config.Verbose {
-				logrus.WithFields(logrus.Fields{"provider": Name, "page": page}).Infof("fetching %s", domain)
-			}
+			logrus.WithFields(logrus.Fields{"provider": Name, "page": page}).Infof("fetching %s", domain)
 			apiURL := c.formatURL(domain, page)
 			resp, err := httpclient.MakeRequest(c.config.Client, apiURL, c.config.MaxRetries, c.config.Timeout)
 			if err != nil {

--- a/pkg/providers/otx/otx.go
+++ b/pkg/providers/otx/otx.go
@@ -78,19 +78,17 @@ paginate:
 }
 
 func (c *Client) formatURL(domain string, page int) string {
+	category := "hostname"
 	if !domainutil.HasSubdomain(domain) {
-		return fmt.Sprintf(_BaseURL+"api/v1/indicators/domain/%s/url_list?limit=100&page=%d",
-			domain, page,
-		)
-	} else if domainutil.HasSubdomain(domain) && c.config.IncludeSubdomains {
-		return fmt.Sprintf(_BaseURL+"api/v1/indicators/domain/%s/url_list?limit=100&page=%d",
-			domainutil.Domain(domain), page,
-		)
-	} else {
-		return fmt.Sprintf(_BaseURL+"api/v1/indicators/hostname/%s/url_list?limit=100&page=%d",
-			domain, page,
-		)
+		category = "domain"
 	}
+	if domainutil.HasSubdomain(domain) && c.config.IncludeSubdomains {
+		domain = domainutil.Domain(domain)
+		category = "domain"
+	}
+
+	return fmt.Sprintf("%sapi/v1/indicators/%s/%s/url_list?limit=100&page=%d", _BaseURL, category, domain, page)
+
 }
 
 var _BaseURL = "https://otx.alienvault.com/"

--- a/pkg/providers/otx/otx.go
+++ b/pkg/providers/otx/otx.go
@@ -47,7 +47,7 @@ func (c *Client) Name() string {
 
 func (c *Client) Fetch(ctx context.Context, domain string, results chan string) error {
 paginate:
-	for page := 1; ; page++ {
+	for page := uint(1); ; page++ {
 		select {
 		case <-ctx.Done():
 			break paginate
@@ -75,7 +75,7 @@ paginate:
 	return nil
 }
 
-func (c *Client) formatURL(domain string, page int) string {
+func (c *Client) formatURL(domain string, page uint) string {
 	category := "hostname"
 	if !domainutil.HasSubdomain(domain) {
 		category = "domain"

--- a/pkg/providers/otx/otx.go
+++ b/pkg/providers/otx/otx.go
@@ -52,9 +52,7 @@ paginate:
 		case <-ctx.Done():
 			break paginate
 		default:
-			if c.config.Verbose {
-				logrus.WithFields(logrus.Fields{"provider": Name, "page": page - 1}).Infof("fetching %s", domain)
-			}
+			logrus.WithFields(logrus.Fields{"provider": Name, "page": page - 1}).Infof("fetching %s", domain)
 			apiURL := c.formatURL(domain, page)
 			resp, err := httpclient.MakeRequest(c.config.Client, apiURL, c.config.MaxRetries, c.config.Timeout)
 			if err != nil {

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -22,7 +22,6 @@ type URLScan struct {
 type Config struct {
 	Threads           uint
 	Timeout           uint
-	Verbose           bool
 	MaxRetries        uint
 	IncludeSubdomains bool
 	RemoveParameters  bool

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/valyala/fasthttp"
 )
 
@@ -27,7 +28,7 @@ type Config struct {
 	RemoveParameters  bool
 	Client            *fasthttp.Client
 	Providers         []string
-	Blacklist         map[string]struct{}
+	Blacklist         mapset.Set[string]
 	Output            string
 	JSON              bool
 	URLScan           URLScan

--- a/pkg/providers/urlscan/types.go
+++ b/pkg/providers/urlscan/types.go
@@ -1,7 +1,6 @@
 package urlscan
 
 import (
-	"reflect"
 	"strings"
 )
 
@@ -29,12 +28,10 @@ type archivedPage struct {
 
 func parseSort(sort []interface{}) string {
 	var sortParam []string
-	for i := 0; i < len(sort); i++ {
-		t := reflect.TypeOf(sort[i])
-		v := reflect.ValueOf(sort[i])
-		switch t.Kind() {
-		case reflect.String:
-			sortParam = append(sortParam, v.String())
+	for _, t := range sort {
+		switch t.(type) {
+		case string:
+			sortParam = append(sortParam, t.(string))
 		}
 	}
 	return strings.Join(sortParam, ",")

--- a/pkg/providers/urlscan/urlscan.go
+++ b/pkg/providers/urlscan/urlscan.go
@@ -41,9 +41,8 @@ func (c *Client) Fetch(ctx context.Context, domain string, results chan string) 
 		header.Value = c.config.URLScan.APIKey
 	}
 
-	page := 0
 paginate:
-	for {
+	for page := 0; ; page++ {
 		select {
 		case <-ctx.Done():
 			break paginate
@@ -65,7 +64,7 @@ paginate:
 			// rate limited
 			if result.Status == 429 {
 				if c.config.Verbose {
-					logrus.WithField("provider", "urlscan").Warnf("urlscan responded with 429")
+					logrus.WithField("provider", "urlscan").Warnf("urlscan responded with 429, probably being rate limited")
 				}
 				break paginate
 			}
@@ -89,7 +88,6 @@ paginate:
 			if !result.HasMore {
 				break paginate
 			}
-			page++
 		}
 	}
 	return nil
@@ -97,10 +95,10 @@ paginate:
 
 func (c *Client) formatURL(domain string, after string) string {
 	if after != "" {
-		return fmt.Sprintf(_BaseURL+"api/v1/search/?q=domain:%s&size=100", domain) + "&search_after=" + after
+		after = "&search_after=" + after
 	}
 
-	return fmt.Sprintf(_BaseURL+"api/v1/search/?q=domain:%s&size=100", domain)
+	return fmt.Sprintf(_BaseURL+"api/v1/search/?q=domain:%s&size=100", domain) + after
 }
 
 func setBaseURL(baseURL string) {

--- a/pkg/providers/urlscan/urlscan.go
+++ b/pkg/providers/urlscan/urlscan.go
@@ -42,7 +42,7 @@ func (c *Client) Fetch(ctx context.Context, domain string, results chan string) 
 	}
 
 paginate:
-	for page := 0; ; page++ {
+	for page := uint(0); ; page++ {
 		select {
 		case <-ctx.Done():
 			break paginate

--- a/pkg/providers/urlscan/urlscan.go
+++ b/pkg/providers/urlscan/urlscan.go
@@ -47,9 +47,7 @@ paginate:
 		case <-ctx.Done():
 			break paginate
 		default:
-			if c.config.Verbose {
-				logrus.WithFields(logrus.Fields{"provider": Name, "page": page}).Infof("fetching %s", domain)
-			}
+			logrus.WithFields(logrus.Fields{"provider": Name, "page": page}).Infof("fetching %s", domain)
 			apiURL := c.formatURL(domain, searchAfter)
 			resp, err := httpclient.MakeRequest(c.config.Client, apiURL, c.config.MaxRetries, c.config.Timeout, header)
 			if err != nil {
@@ -63,9 +61,7 @@ paginate:
 			}
 			// rate limited
 			if result.Status == 429 {
-				if c.config.Verbose {
-					logrus.WithField("provider", "urlscan").Warnf("urlscan responded with 429, probably being rate limited")
-				}
+				logrus.WithField("provider", "urlscan").Warnf("urlscan responded with 429, probably being rate limited")
 				break paginate
 			}
 

--- a/pkg/providers/wayback/wayback.go
+++ b/pkg/providers/wayback/wayback.go
@@ -43,14 +43,13 @@ func (c *Client) Fetch(ctx context.Context, domain string, results chan string) 
 	if err != nil {
 		return fmt.Errorf("failed to fetch wayback pagination: %s", err)
 	}
+
 	for page := uint(0); page < pages; page++ {
 		select {
 		case <-ctx.Done():
 			return nil
 		default:
-			if c.config.Verbose {
-				logrus.WithFields(logrus.Fields{"provider": Name, "page": page}).Infof("fetching %s", domain)
-			}
+			logrus.WithFields(logrus.Fields{"provider": Name, "page": page}).Infof("fetching %s", domain)
 			apiURL := c.formatURL(domain, page)
 			// make HTTP request
 			resp, err := httpclient.MakeRequest(c.config.Client, apiURL, c.config.MaxRetries, c.config.Timeout)

--- a/pkg/providers/wayback/wayback.go
+++ b/pkg/providers/wayback/wayback.go
@@ -22,11 +22,8 @@ type Client struct {
 	config  *providers.Config
 }
 
-func New(c *providers.Config, filters providers.Filters) *Client {
-	return &Client{
-		filters: filters,
-		config:  c,
-	}
+func New(config *providers.Config, filters providers.Filters) *Client {
+	return &Client{filters, config}
 }
 
 func (c *Client) Name() string {
@@ -69,11 +66,9 @@ func (c *Client) Fetch(ctx context.Context, domain string, results chan string) 
 			}
 
 			// output results
-			for i, entry := range result {
-				// Skip first result by default
-				if i != 0 {
-					results <- entry[0]
-				}
+			// Slicing as [1:] to skip first result by default
+			for _, entry := range result[1:] {
+				results <- entry[0]
 			}
 		}
 	}

--- a/runner/flags/flags.go
+++ b/runner/flags/flags.go
@@ -4,18 +4,20 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	mapset "github.com/deckarep/golang-set/v2"
-	"github.com/lc/gau/v2/pkg/providers"
-	"github.com/lynxsecurity/pflag"
-	"github.com/lynxsecurity/viper"
-	log "github.com/sirupsen/logrus"
-	"github.com/valyala/fasthttp"
-	"github.com/valyala/fasthttp/fasthttpproxy"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/lc/gau/v2/pkg/providers"
+	"github.com/lynxsecurity/pflag"
+	"github.com/lynxsecurity/viper"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttpproxy"
 )
 
 type URLScanConfig struct {
@@ -61,7 +63,6 @@ func (c *Config) ProviderConfig() (*providers.Config, error) {
 	pc := &providers.Config{
 		Threads:           c.Threads,
 		Timeout:           c.Timeout,
-		Verbose:           c.Verbose,
 		MaxRetries:        c.MaxRetries,
 		IncludeSubdomains: c.IncludeSubdomains,
 		RemoveParameters:  c.RemoveParameters,
@@ -81,6 +82,10 @@ func (c *Config) ProviderConfig() (*providers.Config, error) {
 		OTX: c.OTX,
 	}
 
+	logrus.SetLevel(log.ErrorLevel)
+	if c.Verbose {
+		logrus.SetLevel(log.InfoLevel)
+	}
 	pc.Blacklist = mapset.NewThreadUnsafeSet(c.Blacklist...)
 	pc.Blacklist.Add("")
 	return pc, nil

--- a/runner/flags/flags.go
+++ b/runner/flags/flags.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/lc/gau/v2/pkg/providers"
 	"github.com/lynxsecurity/pflag"
 	"github.com/lynxsecurity/viper"
@@ -80,11 +81,8 @@ func (c *Config) ProviderConfig() (*providers.Config, error) {
 		OTX: c.OTX,
 	}
 
-	pc.Blacklist = make(map[string]struct{})
-	for _, b := range c.Blacklist {
-		pc.Blacklist[b] = struct{}{}
-	}
-
+	pc.Blacklist = mapset.NewThreadUnsafeSet(c.Blacklist...)
+	pc.Blacklist.Add("")
 	return pc, nil
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -79,7 +79,7 @@ work:
 					wg.Add(1)
 					go func(p providers.Provider) {
 						defer wg.Done()
-						if err := p.Fetch(ctx, domain, results); err != nil && r.config.Verbose {
+						if err := p.Fetch(ctx, domain, results); err != nil {
 							logrus.WithField("provider", p.Name()).Warnf("%s - %v", domain, err)
 						}
 					}(p)


### PR DESCRIPTION
### Changes
- Use switch statement on `interface{}`s instead of reflection to figure out types (bumped go version to 1.20)
- Avoid `goto` statements when possible
- Use mapset library for blocklists and looking up previously seen URLs
- Lazily construct structures when errors are involved
- Set a log level when parsing configs to avoid checking the verbose flag for every logrus log invocation
- Scope loop variables to respective blocks 
- Minor improvements to conditional statements that employ string formatting