### PR TITLE
feat: implement unthrottled concurrency using task queue

### DIFF
--- a/cmd/gau/main.go
+++ b/cmd/gau/main.go
@@ -2,27 +2,20 @@ package main
 
 import (
 	"bufio"
+	"io"
+	"os"
+	"sync"
+
 	"github.com/lc/gau/v2/pkg/output"
 	"github.com/lc/gau/v2/runner"
 	"github.com/lc/gau/v2/runner/flags"
 	log "github.com/sirupsen/logrus"
-	"io"
-	"os"
-	"sync"
 )
 
 func main() {
-	flag := flags.New()
-	cfg, err := flag.ReadInConfig()
+	cfg, err := flags.New().ReadInConfig()
 	if err != nil {
-		if cfg.Verbose {
-			log.Warnf("error reading config: %v", err)
-		}
-	}
-
-	pMap := make(runner.ProvidersMap)
-	for _, provider := range cfg.Providers {
-		pMap[provider] = cfg.Filters
+		log.Warnf("error reading config: %v", err)
 	}
 
 	config, err := cfg.ProviderConfig()
@@ -30,9 +23,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	gau := &runner.Runner{}
+	gau := new(runner.Runner)
 
-	if err = gau.Init(config, pMap); err != nil {
+	if err = gau.Init(config, cfg.Providers, cfg.Filters); err != nil {
 		log.Warn(err)
 	}
 
@@ -40,52 +33,52 @@ func main() {
 
 	var out io.Writer
 	// Handle results in background
-	if config.Output == "" {
-		out = os.Stdout
-	} else {
-		ofp, err := os.OpenFile(config.Output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if config.Output != "" {
+		out, err := os.OpenFile(config.Output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			log.Fatalf("Could not open output file: %v\n", err)
 		}
-		defer ofp.Close()
-		out = ofp
-	}
-
-	writeWg := &sync.WaitGroup{}
-	writeWg.Add(1)
-	if config.JSON {
-		go func() {
-			defer writeWg.Done()
-			output.WriteURLsJSON(out, results, config.Blacklist, config.RemoveParameters)
-		}()
+		defer out.Close()
 	} else {
-		go func() {
-			defer writeWg.Done()
-			if err = output.WriteURLs(out, results, config.Blacklist, config.RemoveParameters); err != nil {
-				log.Fatalf("error writing results: %v\n", err)
-			}
-		}()
+		out = os.Stdout
 	}
 
-	domains := make(chan string)
-	gau.Start(domains, results)
+	writeWg := new(sync.WaitGroup)
+	writeWg.Add(1)
+	go func(JSON bool) {
+		defer writeWg.Done()
+		if JSON {
+			output.WriteURLsJSON(out, results, config.Blacklist, config.RemoveParameters)
+		} else if err = output.WriteURLs(out, results, config.Blacklist, config.RemoveParameters); err != nil {
+			log.Fatalf("error writing results: %v\n", err)
+		}
+	}(config.JSON)
 
-	if len(flags.Args()) > 0 {
-		for _, domain := range flags.Args() {
-			domains <- domain
+	workChan := make(chan runner.Work)
+	gau.Start(workChan, results)
+
+	domains := flags.Args()
+	if len(domains) > 0 {
+		for _, provider := range gau.Providers {
+			for _, domain := range domains {
+				workChan <- runner.NewWork(domain, provider)
+			}
 		}
 	} else {
 		sc := bufio.NewScanner(os.Stdin)
-		for sc.Scan() {
-			domains <- sc.Text()
+		for _, provider := range gau.Providers {
+			for sc.Scan() {
+				workChan <- runner.NewWork(sc.Text(), provider)
+
+				if err := sc.Err(); err != nil {
+					log.Fatal(err)
+				}
+			}
 		}
 
-		if err := sc.Err(); err != nil {
-			log.Fatal(err)
-		}
 	}
 
-	close(domains)
+	close(workChan)
 
 	// wait for providers to fetch URLS
 	gau.Wait()

--- a/pkg/providers/commoncrawl/commoncrawl.go
+++ b/pkg/providers/commoncrawl/commoncrawl.go
@@ -64,11 +64,10 @@ func (c *Client) Fetch(ctx context.Context, domain string, results chan string) 
 		return nil
 	}
 
-paginate:
 	for page := uint(0); page < p.Pages; page++ {
 		select {
 		case <-ctx.Done():
-			break paginate
+			return nil
 		default:
 			logrus.WithFields(logrus.Fields{"provider": Name, "page": page}).Infof("fetching %s", domain)
 			apiURL := c.formatURL(domain, page)

--- a/pkg/providers/otx/otx.go
+++ b/pkg/providers/otx/otx.go
@@ -46,11 +46,10 @@ func (c *Client) Name() string {
 }
 
 func (c *Client) Fetch(ctx context.Context, domain string, results chan string) error {
-paginate:
 	for page := uint(1); ; page++ {
 		select {
 		case <-ctx.Done():
-			break paginate
+			return nil
 		default:
 			logrus.WithFields(logrus.Fields{"provider": Name, "page": page - 1}).Infof("fetching %s", domain)
 			apiURL := c.formatURL(domain, page)
@@ -68,11 +67,10 @@ paginate:
 			}
 
 			if !result.HasNext {
-				break paginate
+				return nil
 			}
 		}
 	}
-	return nil
 }
 
 func (c *Client) formatURL(domain string, page uint) string {

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const Version = `2.1.2`
+const Version = `2.2.0`
 
 // Provider is a generic interface for all archive fetchers
 type Provider interface {

--- a/runner/flags/flags.go
+++ b/runner/flags/flags.go
@@ -234,13 +234,8 @@ func (o *Options) getFlagValues(c *Config) {
 		c.RemoveParameters = fp
 	}
 
-	if json {
-		c.JSON = true
-	}
-
-	if verbose {
-		c.Verbose = verbose
-	}
+	c.JSON = json
+	c.Verbose = verbose
 
 	// get filter flags
 	mc := o.viper.GetStringSlice("mc")


### PR DESCRIPTION
### Changes
- create worker goroutines specified through CLI
- goroutines steal incoming tasks from a channel and execute them
- workers consume tasks instead of plain domain name strings
- a task consists of a domain and a provider

This approach spawns `n` green threads instead of `n * len(providers)`. Should prevent resource usage from blowing up and help scaling.