### PR TITLE
Add arm64 arch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,9 +10,12 @@ builds:
     goarch:
       - amd64
       - 386
+      - arm64
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: windows
+        goarch: 'arm64'
     main: ./cmd/gau/
 archives:
   - id: tgz


### PR DESCRIPTION
Since `arm64` architecture is quite popular nowadays (new Apple laptops, Raspberry Pi), I thinks that it's a good idea to have builds for it.