### PR TITLE
blacklist path + fix blacklist extension

### DIFF
--- a/cmd/gau/main.go
+++ b/cmd/gau/main.go
@@ -46,8 +46,8 @@ func main() {
 	go func(out io.Writer, JSON bool) {
 		defer writeWg.Done()
 		if JSON {
-			output.WriteURLsJSON(out, results, config.Blacklist, config.RemoveParameters)
-		} else if err = output.WriteURLs(out, results, config.Blacklist, config.RemoveParameters); err != nil {
+			output.WriteURLsJSON(out, results, config.Blacklist, config.BlacklistPaths, config.RemoveParameters)
+		} else if err = output.WriteURLs(out, results, config.Blacklist, config.BlacklistPaths, config.RemoveParameters); err != nil {
 			log.Fatalf("error writing results: %v\n", err)
 		}
 	}(out, config.JSON)

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/valyala/fasthttp"
 )
@@ -28,6 +29,7 @@ type Config struct {
 	Client            *fasthttp.Client
 	Providers         []string
 	Blacklist         mapset.Set[string]
+	BlacklistPaths    mapset.Set[string]
 	Output            string
 	JSON              bool
 	URLScan           URLScan


### PR DESCRIPTION
This PR addresses issues #87 and #124 

It allows to blacklist paths by adding a —blacklist_path flag, the option accepts URLs and subpaths.
It also fixes --blacklist which couldn’t take something without a period (like “—blacklist .png“ was working but not “—blacklist png“).
I created a Blacklisted function in output.go to handle both blacklist and blacklist_flag.