### PR TITLE
Fixes #110, #117, #133, #142, #143, #74: Specify configuration file and check if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ gau -h
 | Flag | Description | Example |
 |------|-------------|---------|
 |`--blacklist`| list of extensions to skip | gau --blacklist ttf,woff,svg,png|
+|`--config` | Use alternate configuration file (default `$HOME/config.toml` or `%USERPROFILE%\.gau.toml`) | gau --config $HOME/.config/gau.toml|
 |`--fc`| list of status codes to filter | gau --fc 404,302 |
 |`--from`| fetch urls from date (format: YYYYMM) | gau --from 202101 |
 |`--ft`| list of mime-types to filter | gau --ft text/plain|
@@ -48,7 +49,9 @@ $ gau -h
 
 
 ## Configuration Files
-gau automatically looks for a configuration file at `$HOME/.gau.toml` or`%USERPROFILE%\.gau.toml`. You can specify options and they will be used for every subsequent run of gau. Any options provided via command line flags will override options set in the configuration file.
+gau automatically looks for a configuration file at `$HOME/.gau.toml` or`%USERPROFILE%\.gau.toml`. You can point to a different configuration file using the `--config` flag. **If the configuration file is not found, gau will still run with a default configuration, but will output a message to stderr**.
+
+You can specify options and they will be used for every subsequent run of gau. Any options provided via command line flags will override options set in the configuration file.
 
 An example configuration file can be found [here](https://github.com/lc/gau/blob/master/.gau.toml)
 

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const Version = `2.2.3`
+const Version = `2.2.4`
 
 // Provider is a generic interface for all archive fetchers
 type Provider interface {

--- a/runner/flags/flags.go
+++ b/runner/flags/flags.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -143,6 +144,10 @@ func (o *Options) ReadInConfig() (*Config, error) {
 }
 
 func (o *Options) ReadConfigFile(name string) (*Config, error) {
+	if _, err := os.Stat(name); errors.Is(err, os.ErrNotExist) {
+		return o.DefaultConfig(), fmt.Errorf("Config file %s not found, using default config", name)
+	}
+
 	o.viper.SetConfigFile(name)
 
 	if err := o.viper.ReadInConfig(); err != nil {

--- a/runner/flags/flags.go
+++ b/runner/flags/flags.go
@@ -99,6 +99,7 @@ func New() *Options {
 	v := viper.New()
 
 	pflag.String("o", "", "filename to write results to")
+	pflag.String("config", "", "location of config file (default $HOME/.gau.toml or %USERPROFILE%\\.gau.toml)")
 	pflag.Uint("threads", 1, "number of workers to spawn")
 	pflag.Uint("timeout", 45, "timeout (in seconds) for HTTP client")
 	pflag.Uint("retries", 0, "retries for HTTP client")
@@ -134,12 +135,17 @@ func Args() []string {
 }
 
 func (o *Options) ReadInConfig() (*Config, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return o.DefaultConfig(), err
+	confFile := o.viper.GetString("config")
+
+	if confFile == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return o.DefaultConfig(), err
+		}
+
+		confFile = filepath.Join(home, ".gau.toml")
 	}
 
-	confFile := filepath.Join(home, ".gau.toml")
 	return o.ReadConfigFile(confFile)
 }
 


### PR DESCRIPTION
@lc I've changed the error message to be more descriptive and added some details to the README to hopefully reduce confusion (such as that from #133, #110 and #142). If you think that it's better to silently use the default, we can do that.